### PR TITLE
Making use native driver required

### DIFF
--- a/src/common/Interfaces.ts
+++ b/src/common/Interfaces.ts
@@ -64,6 +64,7 @@ export abstract class App {
 
 export abstract class UserInterface {
     abstract setMainView(element: React.ReactElement<any>): void;
+    abstract setContextWrapper(contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>)): void;
     abstract registerRootView(viewKey: string, getComponentFunc: Function): void;
 
     abstract useCustomScrollbars(enable?: boolean): void;

--- a/src/common/Types.ts
+++ b/src/common/Types.ts
@@ -1091,7 +1091,7 @@ export namespace Animated {
     }
 
     export interface AnimationConfig {
-        useNativeDriver?: boolean;
+        useNativeDriver: boolean;
         isInteraction?: boolean;
     }
 

--- a/src/native-common/Accessibility.ts
+++ b/src/native-common/Accessibility.ts
@@ -25,24 +25,24 @@ export class Accessibility extends CommonAccessibility {
     constructor() {
         super();
 
-        let initialStateChanged = false;
+        let initialScreenReaderState = false;
 
         // Some versions of RN don't support this interface.
         if (RN.AccessibilityInfo) {
             // Subscribe to an event to get notified when screen reader is enabled or disabled.
-            RN.AccessibilityInfo.addEventListener('change', (isEnabled: boolean) => {
-                initialStateChanged = true;
+            RN.AccessibilityInfo.addEventListener('screenReaderChanged', (isEnabled: boolean) => {
+                initialScreenReaderState = true;
                 this._updateScreenReaderStatus(isEnabled);
             });
 
             // Fetch initial state.
-            RN.AccessibilityInfo.fetch().then(isEnabled => {
-                if (!initialStateChanged) {
+            RN.AccessibilityInfo.isScreenReaderEnabled().then(isEnabled => {
+                if (!initialScreenReaderState) {
                     this._updateScreenReaderStatus(isEnabled);
                 }
             }).catch(err => {
                 if (AppConfig.isDevelopmentMode()) {
-                    console.error('Accessibility: RN.AccessibilityInfo.fetch failed');
+                    console.error('Accessibility: RN.AccessibilityInfo.isScreenReaderEnabled failed');
                 }
             });
         }

--- a/src/native-common/Button.tsx
+++ b/src/native-common/Button.tsx
@@ -376,6 +376,7 @@ export class Button extends ButtonBase {
                 toValue: value,
                 duration: duration,
                 easing: Animated.Easing.InOut(),
+                useNativeDriver: true
             },
         ).start();
     }

--- a/src/native-common/MainViewStore.ts
+++ b/src/native-common/MainViewStore.ts
@@ -13,6 +13,8 @@ import SubscribableEvent from 'subscribableevent';
 
 export class MainViewStore extends SubscribableEvent<() => void> {
     private _mainView: React.ReactElement<any> | undefined;
+    private _contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>) | undefined;
+
 
     getMainView(): React.ReactElement<any> | undefined {
         return this._mainView;
@@ -20,6 +22,15 @@ export class MainViewStore extends SubscribableEvent<() => void> {
 
     setMainView(view: React.ReactElement<any>): void {
         this._mainView = view;
+        this.fire();
+    }
+
+    getContextWrapper(): ((rootView: React.ReactElement<any>) => React.ReactElement<any>) | undefined {
+        return this._contextWrapper;
+    }
+
+    setContextWrapper(contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>)): void {
+        this._contextWrapper = contextWrapper;
         this.fire();
     }
 }

--- a/src/native-common/RootView.tsx
+++ b/src/native-common/RootView.tsx
@@ -35,6 +35,7 @@ interface RootViewPropsWithMainViewType extends BaseRootViewProps {
 
 interface RootViewState {
     mainView?: any;
+    contextWrapper?: (rootView: React.ReactElement<any>) => React.ReactElement<any>;
     announcementText?: string;
 }
 
@@ -144,7 +145,12 @@ abstract class BaseRootView<P extends BaseRootViewProps> extends React.Component
             </RN.Animated.View>
         );
 
-        return this.renderTopView(content);
+        const maybeContextWrappedContent =
+            this.state.contextWrapper === undefined
+            ? content
+            : this.state.contextWrapper(content);
+
+        return this.renderTopView(maybeContextWrappedContent);
     }
 
     protected _renderAnnouncerView(): JSX.Element {
@@ -193,13 +199,15 @@ class RootViewUsingStore extends BaseRootView<BaseRootViewProps> {
 
     private _getStateFromStore(): RootViewState {
         let mainView = MainViewStore.getMainView();
+        let contextWrapper = MainViewStore.getContextWrapper();
 
         if (mainView && !isEqual(mainView.props, this._mainViewProps)) {
             mainView = React.cloneElement(mainView, this._mainViewProps);
         }
 
         return {
-            mainView: mainView,
+            mainView:       mainView,
+            contextWrapper: contextWrapper,
         };
     }
 

--- a/src/native-common/UserInterface.tsx
+++ b/src/native-common/UserInterface.tsx
@@ -137,6 +137,10 @@ export class UserInterface extends RX.UserInterface {
         MainViewStore.setMainView(element);
     }
 
+    setContextWrapper(contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>)): void {
+        MainViewStore.setContextWrapper(contextWrapper);
+    }
+
     registerRootViewUsingPropsFactory(factory: RN.ComponentProvider) {
         this._rootViewUsingPropsFactory = factory;
     }

--- a/src/native-common/View.tsx
+++ b/src/native-common/View.tsx
@@ -440,6 +440,7 @@ export class View extends ViewBase<RX.Types.ViewProps, RX.Types.Stateless, RN.Vi
                 toValue: value,
                 duration: duration,
                 easing: Animated.Easing.InOut(),
+                useNativeDriver: true
             },
         ).start();
     }

--- a/src/web/FrontLayerViewManager.tsx
+++ b/src/web/FrontLayerViewManager.tsx
@@ -37,9 +37,15 @@ export class FrontLayerViewManager {
     private _isRtlAllowed = true;
     private _isRtlForced = false;
 
+    private _contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>) | undefined;
+
     setMainView(element: React.ReactElement<any>): void {
         this._mainView = element;
         this._renderRootView();
+    }
+
+    setContextWrapper(contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>)): void {
+        this._contextWrapper = contextWrapper;
     }
 
     isModalDisplayed(modalId?: string): boolean {
@@ -205,7 +211,12 @@ export class FrontLayerViewManager {
 
         const container = document.getElementsByClassName('app-container')[0];
 
-        ReactDOM.render(rootView, container);
+        const maybeContextWrappedRootView =
+            this._contextWrapper === undefined
+            ? rootView
+            : this._contextWrapper(rootView);
+
+        ReactDOM.render(maybeContextWrappedRootView, container);
     }
 
     isPopupDisplayed(popupId?: string): boolean {

--- a/src/web/UserInterface.ts
+++ b/src/web/UserInterface.ts
@@ -114,6 +114,10 @@ export class UserInterface extends RX.UserInterface {
         FrontLayerViewManager.setMainView(element);
     }
 
+    setContextWrapper(contextWrapper: ((rootView: React.ReactElement<any>) => React.ReactElement<any>)): void {
+        FrontLayerViewManager.setContextWrapper(contextWrapper);
+    }
+
     registerRootView(viewKey: string, getComponentFunc: Function): void {
         // Nothing to do
     }


### PR DESCRIPTION
Updated react native shows warning if any animation timing didn't have `useNativeDriver` defined. 

Made that field required in types and also updated button and view animation component with it.